### PR TITLE
alkemy-spring module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The objective is to provide more fluent definitions for Selenium tests, using a 
 * [Custom test selector](https://github.com/cosmin-marginean/alkemy/wiki/Test-selector-attribute)
 * [Reports](https://github.com/cosmin-marginean/alkemy/wiki/Reports-and-screenshots)
 * [Run multiple browsers in parallel](https://github.com/cosmin-marginean/alkemy/wiki/Running-tests-in-parallel)
+* [Spring Boot Module](#spring-boot-module)
 
 ## Documentation
 * [Reference documentation](https://github.com/cosmin-marginean/alkemy/wiki)
@@ -122,6 +123,10 @@ Any Kotest assertions can be used natively in combination with the Alkemy or Sel
         driver.find("h2").text shouldContain "Login Page"
     }
 ```
+
+## Spring Boot Module
+
+See [alkemy-spring](alkemy-spring/README.md).
 
 ## Documentation
 See [Documentation](https://github.com/cosmin-marginean/alkemy/wiki) for further information.

--- a/alkemy-spring/README.md
+++ b/alkemy-spring/README.md
@@ -1,0 +1,69 @@
+# Alkemy Spring Module
+
+Alkemy module to integrate with Spring Boot.
+
+## Usage
+
+Gradle:
+
+```groovy
+// build.gradle
+testImplementation "io.resoluteworks:alkemy-spring:${alkemyVersion}"
+```
+
+:warning: **Do NOT load [AlkemyKotestExtension](../README.md#kotest-extension).**
+
+Autowire `AlkemyContext` in the constructor together with other Spring beans, e.g.
+
+```kotlin
+class MySpec(alkemyContext: AlkemyContext, service: UserService) : WordSpec() {
+```
+
+Configure Alkemy using Spring configuration properties, e.g.
+
+```yaml
+# src/test/resources/application.yml
+alkemy:
+  base-url: https://the-internet.herokuapp.com
+  headless: true
+```
+
+## Dynamic Configuration
+
+To configure Alkemy dynamically, overwrite the `AlkemyConfig` bean in the test configuration.
+
+For example, to configure `alkemy.base-url` with the webserver port that was randomly assigned
+by Spring Boot Test:
+
+```kotlin
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class DynamicConfigurationTest(alkemyContext: AlkemyContext) : WordSpec() {
+    @TestConfiguration
+    @Lazy   // required to use @LocalServerPort in @TestConfiguration
+    class Configuration {
+        @LocalServerPort
+        private lateinit var serverPort: Number
+
+        @Bean
+        @Primary
+        fun customAlkemyConfig(alkemyProperties: AlkemyProperties) = alkemyProperties.copy(
+            baseUrl = "http://localhost:${serverPort}",
+        ).toAlkemyConfig()
+    }
+```
+
+:warning: Make sure to call `AlkemyProperties#copy()` before calling `AlkemyProperties#toAlkemyConfig()`. Calling
+`AlkemyConfig#copy()` after calling `AlkemyProperties#toAlkemyConfig()` will throw an exception if `baseUrl` is not yet
+specified.
+
+## Disabling Kotest Auto Scan
+
+If Kotest [auto scan](https://kotest.io/docs/framework/project-config.html#runtime-detection) is disabled, you will need
+to manually load the `SpringAutowireConstructorExtension` and `AlkemySpringKotestExtension` extensions in your Project
+config, e.g.
+
+```kotlin
+class ProjectConfig : AbstractProjectConfig() {
+   override fun extensions() = listOf(SpringAutowireConstructorExtension, AlkemySpringKotestExtension)
+}
+```

--- a/alkemy-spring/build.gradle
+++ b/alkemy-spring/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+  id 'alkemy.library-conventions'
+  id 'org.jetbrains.kotlin.plugin.spring' version "${kotlinVersion}"
+}
+
+dependencies {
+  api project(':alkemy')
+  implementation "io.kotest:kotest-runner-junit5-jvm:${kotestVersion}"
+  implementation "io.kotest.extensions:kotest-extensions-spring:${kotestSpringVersion}"
+  implementation "org.springframework.boot:spring-boot-starter-test:${testSpringBootVersion}"
+
+  testImplementation "org.springframework.boot:spring-boot-starter-web:${testSpringBootVersion}"
+}
+
+publishing {
+  publications {
+    mavenJava(MavenPublication) {
+      pom {
+        developers {
+          developer {
+            name = 'Daniel Shuy'
+          }
+        }
+      }
+    }
+  }
+}

--- a/alkemy-spring/gradle.properties
+++ b/alkemy-spring/gradle.properties
@@ -1,0 +1,6 @@
+kotestSpringVersion = 1.1.3
+# the lowest Spring Boot version with all required features
+springBootVersion = 2.2.3.RELEASE
+testSpringBootVersion = 2.7.12
+
+publishDescription = Alkemy module to integrate with Spring Boot

--- a/alkemy-spring/src/main/kotlin/io/alkemy/spring/AlkemyConfiguration.kt
+++ b/alkemy-spring/src/main/kotlin/io/alkemy/spring/AlkemyConfiguration.kt
@@ -1,0 +1,23 @@
+package io.alkemy.spring
+
+import io.alkemy.AlkemyContext
+import io.alkemy.config.AlkemyConfig
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Lazy
+
+@Configuration(proxyBeanMethods = false)
+@Lazy   // so that this @Configuration will be applied after @Lazy @TestConfigurations
+@EnableConfigurationProperties(AlkemyProperties::class)
+class AlkemyConfiguration {
+    @Bean
+    fun defaultAlkemyConfig(alkemyProperties: AlkemyProperties) = alkemyProperties.toAlkemyConfig()
+
+    @Bean
+    fun alkemyContext(alkemyProperties: AlkemyProperties, alkemyConfig: AlkemyConfig) =
+        if (alkemyProperties.pooled)
+            AlkemyContext.PooledDrivers(alkemyConfig)
+        else
+            AlkemyContext.NewDriver(alkemyConfig)
+}

--- a/alkemy-spring/src/main/kotlin/io/alkemy/spring/AlkemyProperties.kt
+++ b/alkemy-spring/src/main/kotlin/io/alkemy/spring/AlkemyProperties.kt
@@ -1,0 +1,38 @@
+package io.alkemy.spring
+
+import io.alkemy.config.AlkemyConfig
+import io.alkemy.config.Browser
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConfigurationProperties(AlkemyProperties.CONFIGURATION_PROPERTIES_PREFIX)
+@ConstructorBinding
+data class AlkemyProperties(
+    val baseUrl: String?,
+    val pooled: Boolean = true,
+    val browser: Browser = AlkemyConfig.DEFAULT_BROWSER,
+    val incognito: Boolean = AlkemyConfig.DEFAULT_INCOGNITO,
+    val maximize: Boolean = AlkemyConfig.DEFAULT_MAXIMIZE,
+    val headless: Boolean = AlkemyConfig.DEFAULT_HEADLESS,
+    val windowWidth: Int = AlkemyConfig.DEFAULT_WINDOW_WIDTH,
+    val windowHeight: Int = AlkemyConfig.DEFAULT_WINDOW_HEIGHT,
+    val implicitWaitMs: Long = AlkemyConfig.DEFAULT_IMPLICIT_WAIT_MS,
+    val testSelectorAttribute: String = AlkemyConfig.DEFAULT_TEST_SELECTOR_ATTRIBUTE,
+) {
+    companion object {
+        const val CONFIGURATION_PROPERTIES_PREFIX = "alkemy"
+    }
+
+    fun toAlkemyConfig() = AlkemyConfig(
+        baseUrl
+            ?: throw IllegalStateException("${AlkemyProperties::class.simpleName}.${::baseUrl.name} must not be null"),
+        browser,
+        incognito,
+        maximize,
+        headless,
+        windowWidth,
+        windowHeight,
+        implicitWaitMs,
+        testSelectorAttribute,
+    )
+}

--- a/alkemy-spring/src/main/kotlin/io/alkemy/spring/AlkemySpringKotestExtension.kt
+++ b/alkemy-spring/src/main/kotlin/io/alkemy/spring/AlkemySpringKotestExtension.kt
@@ -1,0 +1,19 @@
+package io.alkemy.spring
+
+import io.alkemy.AlkemyContext
+import io.kotest.core.annotation.AutoScan
+import io.kotest.core.extensions.PostInstantiationExtension
+import io.kotest.core.spec.Spec
+import org.springframework.beans.factory.getBean
+import org.springframework.test.context.TestContextManager
+
+@AutoScan
+object AlkemySpringKotestExtension : PostInstantiationExtension {
+    override suspend fun instantiated(spec: Spec): Spec {
+        val manager = TestContextManager(spec::class.java)
+        val applicationContext = manager.testContext.applicationContext
+        val alkemyContext = applicationContext.getBean<AlkemyContext>()
+        spec.extensions(alkemyContext.report)
+        return spec
+    }
+}

--- a/alkemy-spring/src/main/resources/META-INF/spring.factories
+++ b/alkemy-spring/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  io.alkemy.spring.AlkemyConfiguration

--- a/alkemy-spring/src/test/kotlin/io/alkemy/spring/KotestProjectConfig.kt
+++ b/alkemy-spring/src/test/kotlin/io/alkemy/spring/KotestProjectConfig.kt
@@ -1,0 +1,8 @@
+package io.alkemy.spring
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.extensions.spring.SpringExtension
+
+object KotestProjectConfig : AbstractProjectConfig() {
+    override fun extensions() = listOf(SpringExtension)
+}

--- a/alkemy-spring/src/test/kotlin/io/alkemy/spring/TestApplication.kt
+++ b/alkemy-spring/src/test/kotlin/io/alkemy/spring/TestApplication.kt
@@ -1,0 +1,11 @@
+package io.alkemy.spring
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class TestApplication
+
+fun main(args: Array<String>) {
+    runApplication<TestApplication>(*args)
+}

--- a/alkemy-spring/src/test/kotlin/io/alkemy/spring/examples/ConfigurationProperties.kt
+++ b/alkemy-spring/src/test/kotlin/io/alkemy/spring/examples/ConfigurationProperties.kt
@@ -1,0 +1,26 @@
+package io.alkemy.spring.examples
+
+import io.alkemy.AlkemyContext
+import io.alkemy.config.AlkemyConfig
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.equals.shouldBeEqual
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class ConfigurationProperties(alkemyContext: AlkemyContext) : StringSpec() {
+    init {
+        "configure Alkemy using Spring Configuration Properties" {
+            with(alkemyContext.config) {
+                browser.shouldBeEqual(AlkemyConfig.DEFAULT_BROWSER)
+                baseUrl.shouldBeEqual("https://the-internet.herokuapp.com")
+                incognito.shouldBeEqual(AlkemyConfig.DEFAULT_INCOGNITO)
+                maximize.shouldBeEqual(AlkemyConfig.DEFAULT_MAXIMIZE)
+                headless.shouldBeEqual(true)
+                windowWidth.shouldBeEqual(AlkemyConfig.DEFAULT_WINDOW_WIDTH)
+                windowHeight.shouldBeEqual(AlkemyConfig.DEFAULT_WINDOW_HEIGHT)
+                implicitWaitMs.shouldBeEqual(AlkemyConfig.DEFAULT_IMPLICIT_WAIT_MS)
+                testSelectorAttribute.shouldBeEqual(AlkemyConfig.DEFAULT_TEST_SELECTOR_ATTRIBUTE)
+            }
+        }
+    }
+}

--- a/alkemy-spring/src/test/kotlin/io/alkemy/spring/examples/CustomConfig.kt
+++ b/alkemy-spring/src/test/kotlin/io/alkemy/spring/examples/CustomConfig.kt
@@ -1,0 +1,49 @@
+package io.alkemy.spring.examples
+
+import io.alkemy.AlkemyContext
+import io.alkemy.config.AlkemyConfig
+import io.alkemy.spring.AlkemyProperties
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.equals.shouldBeEqual
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Lazy
+import org.springframework.context.annotation.Primary
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class CustomConfig(alkemyContext: AlkemyContext) : StringSpec() {
+    @TestConfiguration
+    @Lazy   // required to use @LocalServerPort in @TestConfiguration
+    class Configuration {
+        @LocalServerPort
+        private lateinit var serverPort: Number
+
+        @Bean
+        @Primary
+        fun customAlkemyConfig(alkemyProperties: AlkemyProperties) = alkemyProperties.copy(
+            baseUrl = "http://localhost:${serverPort}",
+        ).toAlkemyConfig()
+    }
+
+    @LocalServerPort
+    private lateinit var serverPort: Number
+
+    init {
+        "run with custom config" {
+            with(alkemyContext.config) {
+                browser.shouldBeEqual(AlkemyConfig.DEFAULT_BROWSER)
+                baseUrl.shouldBeEqual("http://localhost:${serverPort}")
+                incognito.shouldBeEqual(AlkemyConfig.DEFAULT_INCOGNITO)
+                maximize.shouldBeEqual(AlkemyConfig.DEFAULT_MAXIMIZE)
+                headless.shouldBeEqual(true)    // set by application.yml
+                windowWidth.shouldBeEqual(AlkemyConfig.DEFAULT_WINDOW_WIDTH)
+                windowHeight.shouldBeEqual(AlkemyConfig.DEFAULT_WINDOW_HEIGHT)
+                implicitWaitMs.shouldBeEqual(AlkemyConfig.DEFAULT_IMPLICIT_WAIT_MS)
+                testSelectorAttribute.shouldBeEqual(AlkemyConfig.DEFAULT_TEST_SELECTOR_ATTRIBUTE)
+            }
+        }
+    }
+}

--- a/alkemy-spring/src/test/resources/application.yml
+++ b/alkemy-spring/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+alkemy:
+  base-url: https://the-internet.herokuapp.com
+  headless: true

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,4 +2,5 @@ rootProject.name = 'alkemy-root'
 
 include(
     'alkemy',
+    'alkemy-spring',
 )


### PR DESCRIPTION
To use Alkemy with Spring Boot

Closes #2

I've broken down the PR into multiple commits to make it easier to review:
- Move core code to subproject
    - Convert to multi-module Gradle project
- `WebDriverPool`: Add multi-browser support
    - Previously, it would fetch the `ThreadLocal` `WebDriver`, even if it was for the wrong browser
- `AlkemyConfig`: Don't read system properties eagerly
    - Move logic to read system properties from constructor to a new `AlkemyConfig.systemProperties()` method
    - `AlkemyConfig::systemProperties` is now `lazy`
- Allow `WebDriverPool` to be used with custom configuration
    - Previously, using `AlkemyContext.withConfig(AlkemyConfig)` will not use the `WebDriverPool`
- Remove `@AutoScan` from `AlkemySpecConstructor`
    - `AlkemySpecConstructor` must be disabled for `alkemy-spring`
    - Unfortunately Kotest doesn't have a way of excluding specific `@AutoScan` extensions
    - **Note: This is a breaking change**. I will add it to the documentation.
- Fix `logback-classic` version to match `slf4j-api` version
    - The project uses `slf4j-api` `1.x.x`, but `logback-classic` `1.3.7` depends on `slf4j-api` `2.x.x`
    - I've downgraded `logback-classic` to `1.2.12`, which depends on `slf4j-api` `1.x.x`, which also happens to be the version used by Spring Boot
- Add `alkemy-spring` module