### PR TITLE
Skip signing when publishing to mavenLocal

### DIFF
--- a/buildSrc/src/main/groovy/alkemy.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/alkemy.library-conventions.gradle
@@ -43,6 +43,7 @@ test {
 }
 
 signing {
+  required { !version.toString().contains("-dev-experimental") && gradle.taskGraph.hasTask("publish") }
   sign publishing.publications.mavenJava
 }
 


### PR DESCRIPTION
Configure `signing` plugin to not require secret key configuration when publishing to `mavenLocal` (https://docs.gradle.org/current/userguide/signing_plugin.html#sec:conditional_signing).

This eases testing for contributors who do not need to publish to Maven Central.