### PR TITLE
Auto-download Chrome WebDriver

### DIFF
--- a/buildSrc/src/main/groovy/alkemy.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/alkemy.library-conventions.gradle
@@ -38,7 +38,6 @@ test {
   testLogging {
     showStandardStreams = true
   }
-  systemProperty 'webdriver.chrome.driver', "${rootDir}/chromedriver"
   systemProperty 'kotest.framework.parallelism', '4'
 }
 

--- a/sample-project/README.md
+++ b/sample-project/README.md
@@ -1,12 +1,5 @@
 # Alkemy Sample Project
 
-To run this project you will need the Chrome Driver for your operating system which you can download from [here](https://chromedriver.chromium.org/downloads).
-
-Once downloaded, please update `build.gradle` to set the path to the Chrome Driver executable:
-```groovy
-    systemProperty "webdriver.chrome.driver", "./chromedriver"
-```
-
 To execute all the test run the following:
 ```shell
 ./gradlew clean test

--- a/sample-project/build.gradle
+++ b/sample-project/build.gradle
@@ -32,7 +32,6 @@ test {
     testLogging {
         showStandardStreams = true
     }
-    systemProperty "webdriver.chrome.driver", "./chromedriver"
     systemProperty "kotest.framework.parallelism", "4"
 
     systemProperty "alkemy.browser", "chrome"


### PR DESCRIPTION
I noticed that the Firefox tests were able to run without specifying `webdriver.gecko.driver`.

Turns out since Selenium `4.6`, Selenium will automatically download the right web drivers if they are not already available (https://www.selenium.dev/documentation/webdriver/troubleshooting/errors/driver_location/#use-the-latest-version-of-selenium)

Therefore it is better to let Selenium manage the web drivers, instead of configuring `webdriver.chrome.driver`. This removes the need to copy the Chrome WebDriver to the project root or modify the build file.

To use a specific web driver, the web driver can still be placed on the `PATH`, or `gradlew` can be run with `-Dwebdriver.chrome.driver` or `-Dwebdriver.gecko.driver`.

This also simplifies the `sample-project` setup.