### PR TITLE
Exclude Alkemy Spring from a test

### DIFF
--- a/alkemy-spring/README.md
+++ b/alkemy-spring/README.md
@@ -56,6 +56,16 @@ class DynamicConfigurationTest(alkemyContext: AlkemyContext) : WordSpec() {
 `AlkemyConfig#copy()` after calling `AlkemyProperties#toAlkemyConfig()` will throw an exception if `baseUrl` is not yet
 specified.
 
+## Excluding Alkemy from a test
+
+To exclude Alkemy from a test, exclude `AlkemyConfiguration` using `@EnableAutoConfiguration#exclude`, e.g.
+
+```kotlin
+@SpringBootTest
+@EnableAutoConfiguration(exclude = [AlkemyConfiguration::class])
+class MySpec(service: UserService) : WordSpec() {
+```
+
 ## Disabling Kotest Auto Scan
 
 If Kotest [auto scan](https://kotest.io/docs/framework/project-config.html#runtime-detection) is disabled, you will need

--- a/alkemy-spring/src/main/kotlin/io/alkemy/spring/AlkemySpringKotestExtension.kt
+++ b/alkemy-spring/src/main/kotlin/io/alkemy/spring/AlkemySpringKotestExtension.kt
@@ -4,7 +4,7 @@ import io.alkemy.AlkemyContext
 import io.kotest.core.annotation.AutoScan
 import io.kotest.core.extensions.PostInstantiationExtension
 import io.kotest.core.spec.Spec
-import org.springframework.beans.factory.getBean
+import org.springframework.beans.factory.getBeanProvider
 import org.springframework.test.context.TestContextManager
 
 @AutoScan
@@ -12,8 +12,9 @@ object AlkemySpringKotestExtension : PostInstantiationExtension {
     override suspend fun instantiated(spec: Spec): Spec {
         val manager = TestContextManager(spec::class.java)
         val applicationContext = manager.testContext.applicationContext
-        val alkemyContext = applicationContext.getBean<AlkemyContext>()
-        spec.extensions(alkemyContext.report)
+        applicationContext.getBeanProvider<AlkemyContext>()
+            .ifAvailable
+            ?.let { alkemyContext -> spec.extensions(alkemyContext.report) }
         return spec
     }
 }


### PR DESCRIPTION
A project may have both unit tests and integration tests. This allows `AlkemyConfiguration` to be excluded from a test so that it doesn't fail if `alkemy-spring` is not configured for a test that does not need to use Alkemy