### PR TITLE
Handle Kotest auto-scan disabled and ReportContext not registered

### DIFF
--- a/alkemy/src/main/kotlin/io/alkemy/reports/ReportContext.kt
+++ b/alkemy/src/main/kotlin/io/alkemy/reports/ReportContext.kt
@@ -37,8 +37,13 @@ object ReportContext : BeforeProjectListener, AfterProjectListener, PrepareSpecL
     }
 
     fun createTestCaseNode(testCase: TestCase) {
-        log.debug("Creating report node test for: ${testCase.spec::class.simpleName!!}.testCase.name.testName")
-        val node = specTests[testCase.spec::class.simpleName!!]!!.createNode(testCase.name.testName)
+        val specName = testCase.spec::class.simpleName
+        val specTest = specTests[specName]
+            ?: return // if auto-scan is disabled and ReportContext is not registered
+
+        val testName = testCase.name.testName
+        log.debug("Creating report node test for: $specName.$testName")
+        val node = specTest.createNode(testName)
         testNodes[testCase] = node
     }
 


### PR DESCRIPTION
If Kotest [auto scan](https://kotest.io/docs/framework/project-config.html#runtime-detection) is disabled and the `ReportContext` extension is not manually registered, certain functions will fail with `NullPointerException` because the `ExtentTest` is not found.

This skips the Extent reporting if the `ExtentTest` is not found (`ReportContext` is not registered).