### PR TITLE
Use relative paths to screenshots in report

### DIFF
--- a/alkemy/src/main/kotlin/io/alkemy/reports/AlkemyReport.kt
+++ b/alkemy/src/main/kotlin/io/alkemy/reports/AlkemyReport.kt
@@ -11,7 +11,6 @@ import io.kotest.core.test.TestResult
 import org.openqa.selenium.OutputType
 import org.openqa.selenium.TakesScreenshot
 import java.nio.file.Paths
-import kotlin.io.path.absolutePathString
 import kotlin.io.path.createDirectories
 import kotlin.io.path.writeBytes
 
@@ -38,8 +37,11 @@ class AlkemyReport(
             return
         }
 
+        // use relative paths to screenshots in report
+        // we need to prepend ./ for img.src to look for the path relative to the file, not the server root
+        val relativePngFilePath = "./${Paths.get(ReportConfig.htmlReportFile).parent.relativize(pngFile)}"
         val media =
-            MediaEntityBuilder.createScreenCaptureFromPath(pngFile.absolutePathString(), if (failure) "Test failed" else null)
+            MediaEntityBuilder.createScreenCaptureFromPath(relativePngFilePath, if (failure) "Test failed" else null)
                 .build()
 
         if (failure) {

--- a/alkemy/src/main/kotlin/io/alkemy/reports/AlkemyReport.kt
+++ b/alkemy/src/main/kotlin/io/alkemy/reports/AlkemyReport.kt
@@ -10,7 +10,10 @@ import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import org.openqa.selenium.OutputType
 import org.openqa.selenium.TakesScreenshot
-import java.io.File
+import java.nio.file.Paths
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeBytes
 
 class AlkemyReport(
     private val context: AlkemyContext
@@ -23,10 +26,10 @@ class AlkemyReport(
 
     private fun screenshot(node: ExtentTest?, testCase: TestCase, description: String? = null, failure: Boolean = false) {
         val clsName = testCase.spec::class.simpleName!!
-        val parentDir = File(ReportConfig.screenshotDir, clsName)
-        parentDir.mkdirs()
-        val fileName = testCase.name.testName.replace(" ", "-") + "-" + System.currentTimeMillis() + ".png"
-        val pngFile = File(parentDir, fileName)
+        val parentDir = Paths.get(ReportConfig.screenshotDir, clsName)
+        parentDir.createDirectories()
+        val fileName = "${testCase.name.testName.replace(" ", "-")}-${System.currentTimeMillis()}.png"
+        val pngFile = parentDir.resolve(fileName)
 
         val bytes = (context.webDriver as TakesScreenshot).getScreenshotAs(OutputType.BYTES)
         pngFile.writeBytes(bytes)
@@ -36,7 +39,7 @@ class AlkemyReport(
         }
 
         val media =
-            MediaEntityBuilder.createScreenCaptureFromPath(pngFile.absolutePath, if (failure) "Test failed" else null)
+            MediaEntityBuilder.createScreenCaptureFromPath(pngFile.absolutePathString(), if (failure) "Test failed" else null)
                 .build()
 
         if (failure) {


### PR DESCRIPTION
# Why

Currently, the screenshots (`img`) in the Extent HTML report use absolute paths in their `src`, e.g. `/path/to/project/build/reports/screenshots/<TestClassName>/<test-name>-<timestamp>.png`.

This causes the Extent HTML report to not work when the screenshots are moved, e.g. uploaded to GitHub Actions build artifacts.

# What

Use relative paths to screenshots in Extent HTML report, e.g. `./screenshots/<TestClassName>/<test-name>-<timestamp>.png`.

I changed the code to use Java NIO instead of IO to use [Path#relativize(Path)](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html#relativize-java.nio.file.Path-) to relativize the screenshot file paths against the report file path.