### PR TITLE
Support Spring Boot 3

### DIFF
--- a/alkemy-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/alkemy-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.alkemy.spring.AlkemyConfiguration


### PR DESCRIPTION
Spring Boot 3 requires auto-configurations to be registered in `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` instead of `META-INF/spring.factories` (see https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files)

We can keep `META-INF/spring.factories` for backwards compatibility with Spring Boot 2